### PR TITLE
CherryPy plugin doesn't work in djagno 1.8

### DIFF
--- a/nosedjango/plugins/cherrypy_plugin.py
+++ b/nosedjango/plugins/cherrypy_plugin.py
@@ -59,8 +59,8 @@ class CherryPyLiveServerPlugin(Plugin):
         self.stop_test_server()
 
     def start_server(self, address='0.0.0.0', port=8000):
-        from django.core.servers.basehttp import AdminMediaHandler
-        _application = AdminMediaHandler(WSGIHandler())
+        from django.contrib.staticfiles.handlers import StaticFilesHandler
+        _application = StaticFilesHandler(WSGIHandler())
 
         def application(environ, start_response):
             environ['PATH_INFO'] = environ['SCRIPT_NAME'] + environ['PATH_INFO']  # noqa

--- a/nosedjangotests/polls/tests/test0.py
+++ b/nosedjangotests/polls/tests/test0.py
@@ -3,8 +3,10 @@ from django.test import TestCase
 
 from nosedjangotests.polls.models import Choice
 
+
 def _test_using_content_types(self):
     self.assertEqual(Choice.objects.all().count(), 1)
+
 
 class ContentTypeTestCase(TestCase):
     fixtures = [
@@ -17,3 +19,7 @@ class ContentTypeTestCase(TestCase):
 
     def test_using_content_types_2(self):
         _test_using_content_types(self)
+
+
+class CherryPyTestCase(ContentTypeTestCase):
+    start_live_server = True

--- a/nosedjangotests/settings.py
+++ b/nosedjangotests/settings.py
@@ -71,3 +71,5 @@ SILENCED_SYSTEM_CHECKS = [
     # Silence deprecation warning alerting user to a new test runner.
     '1_6.W001',
 ]
+
+STATIC_URL = '/static/'

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,14 @@ class MySQLTestCase(RunTests):
     label = 'MySQL'
 
 
+class CherryPyLiveSerberTestCase(RunTests):
+    label = 'Cherry Py Test Case'
+    args = [
+        '--with-django-sqlite',
+        '--with-cherrypyliveserver',
+    ]
+
+
 class SeleniumTestCase(RunTests):
     label = 'Selenium'
     test_app = 'nosedjangotests.selenium_tests'
@@ -115,6 +123,7 @@ setup(
         'test_multiprocess': MultiProcessTestCase,
         'test_mysql': MySQLTestCase,
         'test_selenium': SeleniumTestCase,
+        'test_cherrypy': CherryPyLiveSerberTestCase,
     },
     include_package_data=True,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ class MySQLTestCase(RunTests):
     label = 'MySQL'
 
 
-class CherryPyLiveSerberTestCase(RunTests):
+class CherryPyLiveServerTestCase(RunTests):
     label = 'Cherry Py Test Case'
     args = [
         '--with-django-sqlite',
@@ -123,7 +123,7 @@ setup(
         'test_multiprocess': MultiProcessTestCase,
         'test_mysql': MySQLTestCase,
         'test_selenium': SeleniumTestCase,
-        'test_cherrypy': CherryPyLiveSerberTestCase,
+        'test_cherrypy': CherryPyLiveServerTestCase,
     },
     include_package_data=True,
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     # For faster tests comment out the next line.
     {envpython} setup.py test_mysql
     {envpython} setup.py test_selenium
+    {envpython} setup.py test_cherrypy
 deps =
     nose1.3.X: nose==1.3
     django1.4.X: django==1.4,<1.5
@@ -19,6 +20,7 @@ deps =
     # Something odd going on with travis won't let those tests pass. Ignore
     # them for now.
     # selenium==2.47
+    CherryPy==3.2.0
     south: south
     mysql-python
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nose/case.py", line 133, in run
    self.runTest(result)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nose/case.py", line 151, in runTest
    test(result)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/django/test/testcases.py", line 186, in __call__
    super(SimpleTestCase, self).__call__(result)
  File "/usr/lib/python2.7/unittest/case.py", line 391, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python2.7/unittest/case.py", line 302, in run
    result.startTest(self)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nose/proxy.py", line 169, in startTest
    self.plugins.startTest(self.test)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nose/plugins/manager.py", line 357, in startTest
    return self.plugin.startTest(test.test)
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nosedjango/plugins/cherrypy_plugin.py", line 53, in startTest
    DEFAULT_LIVE_SERVER_PORT,
  File "/home/ubuntu/virtualenvs/pstat_ticket_selenium_12/lib/python2.7/site-packages/nosedjango/plugins/cherrypy_plugin.py", line 62, in start_server
    from django.core.servers.basehttp import AdminMediaHandler
ImportError: cannot import name AdminMediaHandler
```