### PR TITLE
Test client needs to be set up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+1.0.6
+-------
+
+released TBD
+
+* Create the client in django 1.8 test cases.
+* Fixed a problem with fixture loading
+
 1.0.5
 -------
 

--- a/nosedjango/nosedjango.py
+++ b/nosedjango/nosedjango.py
@@ -505,10 +505,14 @@ class NoseDjango(Plugin):
         from django.core.urlresolvers import clear_url_caches
 
         self.call_plugins_method('beforeDestroyTestDb', settings, connection)
-        connection.creation.destroy_test_db(
-            self.old_db,
-            verbosity=self.verbosity,
-        )
+        try:
+            connection.creation.destroy_test_db(
+                self.old_db,
+                verbosity=self.verbosity,
+            )
+        except Exception:
+            # If we can't tear down the test DB, don't worry about it.
+            pass
         self.call_plugins_method('afterDestroyTestDb', settings, connection)
 
         self.call_plugins_method(

--- a/nosedjango/nosedjango.py
+++ b/nosedjango/nosedjango.py
@@ -483,6 +483,8 @@ class NoseDjango(Plugin):
             self.restore_transaction_support()
             self.enter_atomics()
             self.disable_transaction_support()
+        if hasattr(test.context, 'client_class'):
+            test.context.client = test.context.client_class()
 
     def finalize(self, result=None):
         """

--- a/nosedjango/nosedjango.py
+++ b/nosedjango/nosedjango.py
@@ -158,7 +158,12 @@ class NoseDjango(Plugin):
             # An error occurred, early exit so we don't squash the error
             # message.
             return
-        self.TestCase._rollback_atomics(self.TestCase.cls_atomics)
+        try:
+            self.TestCase._rollback_atomics(self.TestCase.cls_atomics)
+        except Exception:
+            # If we can't roll back atomics, it means we crashed somewhere in
+            # setup. Don't hide that error by eroding here too.
+            pass
 
     def store_original_transaction_methods(self):
         self.orig_commit = self.transaction.commit

--- a/nosedjangotests/polls/tests/test_custom_client.py
+++ b/nosedjangotests/polls/tests/test_custom_client.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from django.test.client import Client
+
+
+class NoseClient(Client):
+    is_nose = True
+
+    def __init__(self):
+        self.items = []
+
+
+class CustomClientTestCase(TestCase):
+    client_class = NoseClient
+
+    def test_client_is_nose(self):
+        assert self.client.is_nose
+
+    def test_AAA_change_client_items(self):
+        self.client.items.append(1)
+
+    def test_BBB_client_items_empty(self):
+        self.assertEqual(self.client.items, [])


### PR DESCRIPTION
For test classes set `client_class`, we are inadvertently not creating the client for those tests. It's only working in PolicyStat because most of the tests that need the client, we are using an out-dated way of creating a custom client.