### PR TITLE
Stop disabling transaction support in django 1.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 1.0.7
 -------
 
+released 2016-01-28
+
+* No longer disable transaction support in django 1.8. It doesn't reliably
+  work, and it isn't required anymore.
+
+1.0.7
+-------
+
 released 2016-01-20
 
 * Selenium plugin can now specify ``--firefox-binary`` to specify path to Firefox

--- a/nosedjango/nosedjango.py
+++ b/nosedjango/nosedjango.py
@@ -176,6 +176,8 @@ class NoseDjango(Plugin):
             self.orig_atomic = self.transaction.atomic
 
     def disable_transaction_support(self):
+        if self.django_version > self.DJANGO_1_7:
+            return
         self.transaction.commit = _dummy
         self.transaction.rollback = _dummy
         self.transaction.savepoint_commit = _dummy


### PR DESCRIPTION
Not only is it not working, but I don't think it's actually needed in django 1.8. All the DB backends now support transactions, so we can still get all the speed bonuses without patching transaction stuff.