### PR TITLE
Allow overrides of the Firefox profile 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+1.0.13
+------
+
+released 2016-04-06
+
+* Selenium plugin can now specify multiple ``--ff-profile`` args in order to
+  override Firefox profile settings.  For example,
+  ``--ff-profile browser.helperApps.neverAsk.saveToDisk="application/ourfakemimetype"``
+  to disable download prompts for a mimetype.
+
 1.0.12
 ------
 

--- a/nosedjango/plugins/selenium_plugin.py
+++ b/nosedjango/plugins/selenium_plugin.py
@@ -65,6 +65,14 @@ class SeleniumPlugin(Plugin):
             ),
             default=None,
         )
+        parser.add_option(
+            '--autodownload-directory',
+            help=(
+                'If specified, will automatically download files'
+                'into this directory.'
+            ),
+            default=None,
+        )
         Plugin.options(self, parser, env)
 
     def configure(self, options, config):
@@ -72,6 +80,8 @@ class SeleniumPlugin(Plugin):
             self.ss_dir = os.path.abspath(options.selenium_ss_dir)
         else:
             self.ss_dir = os.path.abspath('failure_screenshots')
+        if options.autodownload_directory:
+            self.download_directory = os.path.abspath(options.autodownload_directory)
         valid_browsers = ['firefox', 'internet_explorer', 'chrome']
         if options.driver_type not in valid_browsers:
             raise RuntimeError(
@@ -193,6 +203,7 @@ class SeleniumPlugin(Plugin):
         driver = self.get_driver()
         logging.getLogger().setLevel(logging.INFO)
         setattr(test.test, 'driver', driver)
+        setattr(test.test, 'downloads_dir', self.download_directory)
         # need to know the main window handle for cleaning up extra windows at
         # the end of each test
         if driver:

--- a/nosedjango/plugins/selenium_plugin.py
+++ b/nosedjango/plugins/selenium_plugin.py
@@ -66,10 +66,16 @@ class SeleniumPlugin(Plugin):
             default=None,
         )
         parser.add_option(
-            '--autodownload-directory',
+            '--download-directory',
             help=(
-                'If specified, will automatically download files'
-                'into this directory.'
+                'The download directory to use'
+            ),
+            default=None,
+        )
+        parser.add_option(
+            '--autodownload-mimetypes',
+            help=(
+                'If specified, will automatically download these mimetypes'
             ),
             default=None,
         )
@@ -80,15 +86,17 @@ class SeleniumPlugin(Plugin):
             self.ss_dir = os.path.abspath(options.selenium_ss_dir)
         else:
             self.ss_dir = os.path.abspath('failure_screenshots')
-        if options.autodownload_directory:
-            self.download_directory = os.path.abspath(
-                options.autodownload_directory
+        if options.download_directory:
+            self._download_directory = os.path.abspath(
+                options.download_directory
             )
+
         valid_browsers = ['firefox', 'internet_explorer', 'chrome']
         if options.driver_type not in valid_browsers:
             raise RuntimeError(
                 '--driver-type must be one of: %s' % ' '.join(valid_browsers)
             )
+        self._autodownload_mimetypes = options.autodownload_mimetypes
         self._firefox_binary = options.firefox_binary
         self._driver_type = options.driver_type.replace('_', ' ')
         self._remote_server_address = options.remote_server_address
@@ -117,12 +125,40 @@ class SeleniumPlugin(Plugin):
             return self._driver
 
         if self._driver_type == 'firefox':
+            from selenium.webdriver.firefox.firefox_profile import FirefoxProfile  # noqa
+            fp = FirefoxProfile()
+
+            if self._download_directory:
+                fp.set_preference(
+                    "browser.download.dir",
+                    self._download_directory,
+                )
+
+            if self._autodownload_mimetypes:
+                fp.set_preference(
+                    "browser.download.folderList",
+                    2,
+                )
+                fp.set_preference(
+                    "browser.download.manager.showWhenStarting",
+                    False,
+                )
+                fp.set_preference(
+                    "browser.helperApps.neverAsk.saveToDisk",
+                    self._autodownload_mimetypes,
+                )
+
+            self._profile = fp
+
             if self._firefox_binary is None:
-                self._driver = FirefoxWebDriver()
+                self._driver = FirefoxWebDriver(firefox_profile=self._profile)
             else:
                 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary  # noqa
                 binary = FirefoxBinary(self._firefox_binary)
-                self._driver = FirefoxWebDriver(firefox_binary=binary)
+                self._driver = FirefoxWebDriver(
+                    firefox_profile=self._profile,
+                    firefox_binary=binary
+                )
         elif self._driver_type == 'chrome':
             self._driver = ChromeDriver()
         else:
@@ -205,7 +241,7 @@ class SeleniumPlugin(Plugin):
         driver = self.get_driver()
         logging.getLogger().setLevel(logging.INFO)
         setattr(test.test, 'driver', driver)
-        setattr(test.test, 'downloads_dir', self.download_directory)
+        setattr(test.test, 'download_dir', self._download_directory)
         # need to know the main window handle for cleaning up extra windows at
         # the end of each test
         if driver:

--- a/nosedjango/plugins/selenium_plugin.py
+++ b/nosedjango/plugins/selenium_plugin.py
@@ -121,7 +121,6 @@ class SeleniumPlugin(Plugin):
 
             for override in self._ff_profile_overrides:
                 pref, value = override.split('=')
-                print value
                 fp.set_preference(pref, literal_eval(value))
 
             self._profile = fp

--- a/nosedjango/plugins/selenium_plugin.py
+++ b/nosedjango/plugins/selenium_plugin.py
@@ -9,7 +9,6 @@ from pprint import pprint
 import nose.case
 from nosedjango.plugins.base_plugin import Plugin
 
-
 try:
     from urllib2 import URLError
 except ImportError:
@@ -18,13 +17,6 @@ try:
     from httplib import BadStatusLine
 except ImportError:
     from http.client import BadStatusLine
-
-import time
-from pprint import pprint
-
-import nose.case
-
-from nosedjango.plugins.base_plugin import Plugin
 
 
 class SeleniumPlugin(Plugin):

--- a/nosedjango/plugins/selenium_plugin.py
+++ b/nosedjango/plugins/selenium_plugin.py
@@ -81,7 +81,9 @@ class SeleniumPlugin(Plugin):
         else:
             self.ss_dir = os.path.abspath('failure_screenshots')
         if options.autodownload_directory:
-            self.download_directory = os.path.abspath(options.autodownload_directory)
+            self.download_directory = os.path.abspath(
+                options.autodownload_directory
+            )
         valid_browsers = ['firefox', 'internet_explorer', 'chrome']
         if options.driver_type not in valid_browsers:
             raise RuntimeError(

--- a/nosedjangotests/selenium_autodownload_tests/test.py
+++ b/nosedjangotests/selenium_autodownload_tests/test.py
@@ -21,8 +21,8 @@ class SeleniumTestCase(TransactionTestCase):
         )
 
         self.assertEqual(
-            self.download_dir,
-            tempfile.gettempdir()
+            firefox_profile.default_preferences['browser.download.folderList'],
+            2
         )
 
 

--- a/nosedjangotests/selenium_autodownload_tests/test.py
+++ b/nosedjangotests/selenium_autodownload_tests/test.py
@@ -9,9 +9,15 @@ class SeleniumTestCase(TransactionTestCase):
         driver = self.driver
         driver.get('http://www.google.com')
         firefox_profile = self.driver.firefox_profile
+
         self.assertEqual(
-            firefox_profile.default_preference['browser.download.dir'],
-            tempfile.gettmpdir()
+            firefox_profile.default_preferences['browser.download.dir'],
+            tempfile.gettempdir()
+        )
+
+        self.assertEqual(
+            self.download_dir,
+            tempfile.gettempdir()
         )
 
 

--- a/nosedjangotests/selenium_autodownload_tests/test.py
+++ b/nosedjangotests/selenium_autodownload_tests/test.py
@@ -16,6 +16,11 @@ class SeleniumTestCase(TransactionTestCase):
         )
 
         self.assertEqual(
+            firefox_profile.default_preferences['browser.helperApps.neverAsk.saveToDisk'],
+            'application/ourfakemimetype'
+        )
+
+        self.assertEqual(
             self.download_dir,
             tempfile.gettempdir()
         )

--- a/nosedjangotests/selenium_autodownload_tests/test.py
+++ b/nosedjangotests/selenium_autodownload_tests/test.py
@@ -1,0 +1,17 @@
+from django.test import TransactionTestCase
+
+import tempfile
+
+
+class SeleniumTestCase(TransactionTestCase):
+
+    def test_simple(self):
+        driver = self.driver
+        driver.get('http://www.google.com')
+        firefox_profile = self.driver.firefox_profile
+        self.assertEqual(
+            firefox_profile.default_preference['browser.download.dir'],
+            tempfile.gettmpdir()
+        )
+
+

--- a/nosedjangotests/selenium_firefox_profile_tests/test.py
+++ b/nosedjangotests/selenium_firefox_profile_tests/test.py
@@ -25,4 +25,9 @@ class SeleniumTestCase(TransactionTestCase):
             2
         )
 
+        self.assertEqual(
+            firefox_profile.default_preferences['browser.download.manager.showWhenStarting'],
+            False
+        )
+
 

--- a/setup.py
+++ b/setup.py
@@ -100,9 +100,9 @@ class SeleniumTestCase(RunTests):
         '--with-selenium',
     ]
 
-class SeleniumAutoDownloadTestCase(RunTests):
+class SeleniumFirefoxProfileTestCase(RunTests):
     label = 'Selenium'
-    test_app = 'nosedjangotests.selenium_autodownload_tests'
+    test_app = 'nosedjangotests.selenium_firefox_profile_tests'
     check_selenium = True
     args = [
         '--with-selenium',
@@ -164,7 +164,7 @@ setup(
         'test_multiprocess': MultiProcessTestCase,
         'test_mysql': MySQLTestCase,
         'test_selenium': SeleniumTestCase,
-        'test_selenium_autodownload': SeleniumAutoDownloadTestCase,
+        'test_selenium_firefox_profile': SeleniumFirefoxProfileTestCase,
         'test_selenium_binary': SeleniumBinaryTestCase,
         'test_cherrypy': CherryPyLiveServerTestCase,
     },

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ class SeleniumAutoDownloadTestCase(RunTests):
         '--with-selenium',
         '--with-django-sqlite',
         '--download-directory', tempfile.gettempdir(),
+        '--autodownload-mimetypes', 'application/ourfakemimetype',
     ]
 
 class SeleniumBinaryTestCase(RunTests):

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ class SeleniumAutoDownloadTestCase(RunTests):
     check_selenium = True
     args = [
         '--with-selenium',
-        '--autodownload-directory', tempfile.gettempdir(),
+        '--with-django-sqlite',
+        '--download-directory', tempfile.gettempdir(),
     ]
 
 class SeleniumBinaryTestCase(RunTests):

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ setup(
         'test_multiprocess': MultiProcessTestCase,
         'test_mysql': MySQLTestCase,
         'test_selenium': SeleniumTestCase,
+        'test_selenium_autodownload': SeleniumAutoDownloadTestCase,
         'test_selenium_binary': SeleniumBinaryTestCase,
         'test_cherrypy': CherryPyLiveServerTestCase,
     },

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import sys
 
 from setuptools import setup, find_packages, Command
 
+import tempfile
+
 
 class RunTestBase(Command):
     description = "Run the test suite from the tests dir."
@@ -98,6 +100,14 @@ class SeleniumTestCase(RunTests):
         '--with-selenium',
     ]
 
+class SeleniumAutoDownloadTestCase(RunTests):
+    label = 'Selenium'
+    test_app = 'nosedjangotests.selenium_autodownload_tests'
+    check_selenium = True
+    args = [
+        '--with-selenium',
+        '--autodownload-directory', tempfile.gettempdir(),
+    ]
 
 class SeleniumBinaryTestCase(RunTests):
     label = 'Selenium Binary Option'

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,10 @@ class SeleniumAutoDownloadTestCase(RunTests):
     args = [
         '--with-selenium',
         '--with-django-sqlite',
-        '--download-directory', tempfile.gettempdir(),
-        '--autodownload-mimetypes', 'application/ourfakemimetype',
+        '--ff-profile', 'browser.helperApps.neverAsk.saveToDisk="application/ourfakemimetype"',
+        '--ff-profile', 'browser.download.dir="{0}"'.format(tempfile.gettempdir()),
+        '--ff-profile', 'browser.download.folderList=2',
+        '--ff-profile', 'browser.download.manager.showWhenStarting=False'
     ]
 
 class SeleniumBinaryTestCase(RunTests):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     # For faster tests comment out the next line.
     {envpython} setup.py test_mysql
     {envpython} setup.py test_selenium
+    {envpython} setup.py test_selenium_autodownload
     {envpython} setup.py test_selenium_binary
     {envpython} setup.py test_cherrypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     # For faster tests comment out the next line.
     {envpython} setup.py test_mysql
     {envpython} setup.py test_selenium
-    {envpython} setup.py test_selenium_autodownload
+    {envpython} setup.py test_selenium_firefox_profile
     {envpython} setup.py test_selenium_binary
     {envpython} setup.py test_cherrypy
 


### PR DESCRIPTION
It is currently not possible to pass in a Firefox profile in Selenium, which means it is not possible to do things like setting download directory or install extensions.  

Probably ignore the extension case for now, but allow creating a profile and download directory.  