### PR TITLE
selenium plugin --ff-profile default causes NoneType error

### DIFF
--- a/nosedjango/plugins/selenium_plugin.py
+++ b/nosedjango/plugins/selenium_plugin.py
@@ -71,7 +71,7 @@ class SeleniumPlugin(Plugin):
             help=(
                 'Specify overrides for the FireFox profile'
             ),
-            default=None,
+            default=[],
             action='append'
         )
         Plugin.options(self, parser, env)


### PR DESCRIPTION
#55 introduced a regression where the default value of `--ff-profile` cannot be iterated over.

See here: https://github.com/nosedjango/nosedjango/blob/master/nosedjango/plugins/selenium_plugin.py#L74
See here: https://github.com/nosedjango/nosedjango/blob/master/nosedjango/plugins/selenium_plugin.py#L122

```
Traceback (most recent call last):
  File "/home/vagrant/env/bin/nosetests", line 12, in <module>
    load_entry_point('nose==1.3.4', 'console_scripts', 'nosetests')()
  File "/home/vagrant/env/lib/python2.7/site-packages/nose/core.py", line 121, in __init__
    **extra_args)
  File "/usr/lib/python2.7/unittest/main.py", line 95, in __init__
    self.runTests()
  File "/home/vagrant/env/lib/python2.7/site-packages/nose/core.py", line 207, in runTests
    result = self.testRunner.run(self.test)
  File "/home/vagrant/env/lib/python2.7/site-packages/nose/core.py", line 68, in run
    self.config.plugins.finalize(result)
  File "/home/vagrant/env/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/home/vagrant/env/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/home/vagrant/env/lib/python2.7/site-packages/nosedjango/plugins/selenium_plugin.py", line 175, in finalize
    driver = self.get_driver()
  File "/home/vagrant/env/lib/python2.7/site-packages/nosedjango/plugins/selenium_plugin.py", line 122, in get_driver
    for override in self._ff_profile_overrides:
TypeError: 'NoneType' object is not iterable
```
